### PR TITLE
Display SPHAIRA objectives in ORIS agenda

### DIFF
--- a/ORIS/index.html
+++ b/ORIS/index.html
@@ -1246,11 +1246,11 @@
   const TASK_START_FIELD_CANDIDATES = [
     'start','startDate','start_date','from','start_time','startTime','begin','beginDate','begin_date',
     'targetDate','target_date','objectiveDate','objective_date','goalDate','goal_date',
-    'deadline','deadlineDate','deadline_date','date','dueDate','due_date',
+    'deadline','deadlineDate','deadline_date','date','due','dueDate','due_date','due_at',
     'startAt','start_at','plannedStart','planned_start','expectedStart','expected_start'
   ];
   const TASK_END_FIELD_CANDIDATES = [
-    'end','endDate','end_date','dueDate','due_date','to','end_time','endTime',
+    'end','endDate','end_date','due','dueDate','due_date','due_at','to','end_time','endTime',
     'targetDate','target_date','objectiveDate','objective_date','goalDate','goal_date',
     'deadline','deadlineDate','deadline_date','date','finish','finishDate','finish_date',
     'plannedEnd','planned_end','expectedEnd','expected_end','completionDate','completion_date'


### PR DESCRIPTION
## Summary
- include common SPHAIRA objective due date fields when reading tasks so objectives are surfaced in ORIS

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f10df3408333ac77c1d17c8735ed