### PR TITLE
Prevent ORIS shortcuts from firing while typing

### DIFF
--- a/ORIS/index.html
+++ b/ORIS/index.html
@@ -1604,6 +1604,11 @@
 
   // Raccourcis clavier
   document.addEventListener('keydown', (e)=>{
+    const target = e.target;
+    const tag = target?.tagName?.toLowerCase();
+    const isEditable = target?.isContentEditable;
+    const isFormField = tag === 'input' || tag === 'textarea' || tag === 'select';
+    if(isEditable || (isFormField && !target?.readOnly && !target?.disabled)) return;
     if(e.ctrlKey && (e.key==='f' || e.key==='F')){ e.preventDefault(); searchInput.focus(); return; }
     if(e.key==='ArrowLeft'){ e.preventDefault(); prevBtn.click(); }
     if(e.key==='ArrowRight'){ e.preventDefault(); nextBtn.click(); }


### PR DESCRIPTION
## Summary
- guard the global keyboard shortcut handler so it ignores keystrokes typed in editable fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db88569ec48333bea08aaaea14c096