### PR TITLE
Show task badge only for circles with pending tasks

### DIFF
--- a/SPHAIRA/index.html
+++ b/SPHAIRA/index.html
@@ -960,7 +960,8 @@ function syncOpenUrlIcon(){
 /* ====== Tâches ====== */
 function updateTaskBadge(node){
   const old=node.querySelector('.task-badge'); if(old) old.remove();
-  const tasks=node._tasks||[]; if(tasks.length===0) return;
+  const tasks=node._tasks||[];
+  if(!tasks.some(task=>!isTaskMarkedDone(task))) return;
   const b=document.createElement('div'); b.className='task-badge'; b.textContent='⭐';
   b.addEventListener('pointerdown',e=>e.stopPropagation()); b.addEventListener('click',e=>e.stopPropagation());
   node.appendChild(b);


### PR DESCRIPTION
## Summary
- update the task badge logic so the star icon only appears when a circle still has unvalidated tasks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e354750bf88333ae8716fd41539fd7